### PR TITLE
fix: make compatible to macOS

### DIFF
--- a/commands/ignore.js
+++ b/commands/ignore.js
@@ -1,5 +1,4 @@
 const Chalk = require('chalk');
-const {execShellCommand, execPowerShellCommand} = require('../lib');
 
 const ignore = async (paths) => {
   try {
@@ -9,6 +8,7 @@ const ignore = async (paths) => {
     const isLinux = !isWindows && !isMacOS;
 
     if (isWindows) {
+      const execPowerShellCommand = require('../lib/execPowerShellCommand');
       const cmd =
         'Set-Content -Path ' + paths + ' -Stream com.dropbox.ignored -Value 1';
       const response = await execPowerShellCommand(cmd);
@@ -16,11 +16,13 @@ const ignore = async (paths) => {
     }
 
     if (isMacOS) {
+      const execShellCommand = require('../lib/execShellCommand');
       const cmd = `xattr -w com.dropbox.ignored 1 ${paths.replace(' ', '\\ ')}`;
       return await execShellCommand(cmd);
     }
 
     if (isLinux) {
+      const execShellCommand = require('../lib/execShellCommand');
       const cmd = `attr -s com.dropbox.ignored -V 1 ${paths}`;
       return await execShellCommand(cmd);
     }

--- a/commands/revoke.js
+++ b/commands/revoke.js
@@ -1,5 +1,4 @@
 const Chalk = require('chalk');
-const {execShellCommand, execPowerShellCommand} = require('../lib');
 
 const revoke = async (paths) => {
   try {
@@ -9,6 +8,7 @@ const revoke = async (paths) => {
     const isLinux = !isWindows && !isMacOS;
 
     if (isWindows) {
+      const execPowerShellCommand = require('../lib/execPowerShellCommand');
       const cmd =
         'Clear-Content -Path ' + paths + ' -Stream com.dropbox.ignored';
       const response = await execPowerShellCommand(cmd);
@@ -16,11 +16,13 @@ const revoke = async (paths) => {
     }
 
     if (isMacOS) {
+      const execShellCommand = require('../lib/execShellCommand');
       const cmd = `xattr -d com.dropbox.ignored ${paths.replace(' ', '\\ ')}`;
       return await execShellCommand(cmd);
     }
 
     if (isLinux) {
+      const execShellCommand = require('../lib/execPowerShellCommand');
       const cmd = `attr -r com.dropbox.ignored ${paths}`;
       return await execShellCommand(cmd);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,0 @@
-const execShellCommand = require("./execShellCommand");
-const execPowerShellCommand = require("./execPowerShellCommand");
-
-module.exports = {
-  execShellCommand,
-  execPowerShellCommand,
-};


### PR DESCRIPTION
Current implementation is not compatible to macOS. Reason is that PowerShell is instantiated also on macOS. This PR instantiates shells lately after knowing the OS.